### PR TITLE
Remove notification to configure tab hiding

### DIFF
--- a/conex-background.js
+++ b/conex-background.js
@@ -276,11 +276,6 @@ const showTabs = async function(tabIds) {
 
 const hideTabs = async function(tabIds) {
   browser.tabs.hide(tabIds.pop()).catch(e => {
-    browser.notifications.create(null, {
-      type: 'basic',
-      title: 'Configuration setting missing',
-      message: 'Tab hiding has to be manually configured in order to work. Please see conex settings for instructions.',
-    })
     console.log('please activate tab hiding', e);
   });
 


### PR DESCRIPTION
In case user doesn't want to enable tab hiding the message is useless
and annoying as it appear every time tab is changed.

Related to #128