### PR TITLE
manifest.json: description (60.0a1 and later), terminology (MacCtrl)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "author": "kesselborn",
-  "description": "This is a tabgroup'esque successor for Firefox >= 57 (WebExtensions)",
+  "description": "A tabgroup'esque successor for Firefox 60.0a1 and later",
   "homepage_url": "https://github.com/kesselborn/conex",
   "name": "Conex",
   "version": "0.7.4",
@@ -22,7 +22,7 @@
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {
-        "default": "MacCtrl+Space"
+        "default": "Ctrl+Space"
       }
     },
     "_execute_page_action": {


### PR DESCRIPTION
I'm not sure about the change from 'MacCtrl' to 'Ctrl'; edit if necessary. 